### PR TITLE
[FIX]将第四章计算字段中release_time修改为release_date，保持前后文一致

### DIFF
--- a/Chapter-4/Computed-field.md
+++ b/Chapter-4/Computed-field.md
@@ -28,7 +28,7 @@ class Bangumi(models.Model):
         ('quarterly', 'Update quarterly')
     ], string='Update cycle', required=True, default='weekly')
 
-    release_time = fields.Date(string='Release date', default=fields.Date.today(), required=True)
+    release_date = fields.Date(string='Release date', default=fields.Date.today(), required=True)
 ```
 
 其中 `update_cycle` 使用了一个选择字段，相当于这个字段的值只能是 `weekly`、`monthly` 或者 `quarterly`，并且值所在的元组的第二个元素则是他们具体显示的值。  


### PR DESCRIPTION
[FIX]将第四章计算字段中release_time修改为release_date，修复因前后文不一致而导致的报错问题